### PR TITLE
Bad changes for ClickHouse logs task https://github.com/yandex/ClickHouse/issues/5041

### DIFF
--- a/Foundation/include/Poco/Logger.h
+++ b/Foundation/include/Poco/Logger.h
@@ -442,7 +442,10 @@ public:
 		///
 		/// The level is not case sensitive.
 		
-	static const std::string ROOT; /// The name of the root logger ("").	
+	static const std::string ROOT; /// The name of the root logger ("").
+
+    void force_log(const std::string& text, Message::Priority prio);
+    void force_log(const std::string& text, Message::Priority prio, const char* file, int line);
 		
 protected:
 	typedef std::map<std::string, Logger*> LoggerMap;
@@ -608,6 +611,24 @@ inline const std::string& Logger::name() const
 inline int Logger::getLevel() const
 {
 	return _level;
+}
+
+
+inline void Logger::force_log(const std::string& text, Message::Priority prio)
+{
+    if (_pChannel)
+    {
+        _pChannel->log(Message(_name, text, prio));
+    }
+}
+
+
+inline void Logger::force_log(const std::string& text, Message::Priority prio, const char* file, int line)
+{
+    if (_pChannel)
+    {
+        _pChannel->log(Message(_name, text, prio, file, line));
+    }
 }
 
 

--- a/Foundation/include/Poco/Logger.h
+++ b/Foundation/include/Poco/Logger.h
@@ -444,8 +444,9 @@ public:
 		
 	static const std::string ROOT; /// The name of the root logger ("").
 
-    void force_log(const std::string& text, Message::Priority prio);
-    void force_log(const std::string& text, Message::Priority prio, const char* file, int line);
+	void force_log(const std::string& text, Message::Priority prio);
+	void force_log(const std::string& text, Message::Priority prio, const char* file, int line);
+		///Logs text without priority checking
 		
 protected:
 	typedef std::map<std::string, Logger*> LoggerMap;


### PR DESCRIPTION
To fix this bug, we need to change class Poco::Logger, because we need print log in case when server logs level is low. Poco's logger compares message's level and its internal level before pushing this log. It pushes it to a channel and some other class send it to client with TCP.  We can push our logs directly to client with TCP, but it is much harder. 