### PR TITLE
Set socket timeout even in case of POCO_BROKEN_TIMEOUTS.

### DIFF
--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -595,14 +595,13 @@ int SocketImpl::getReceiveBufferSize()
 
 void SocketImpl::setSendTimeout(const Poco::Timespan& timeout)
 {
-#if defined(_WIN32) && !defined(POCO_BROKEN_TIMEOUTS)
+#if defined(_WIN32)
 	int value = (int) timeout.totalMilliseconds();
 	setOption(SOL_SOCKET, SO_SNDTIMEO, value);
-#elif !defined(POCO_BROKEN_TIMEOUTS)
+#else
 	setOption(SOL_SOCKET, SO_SNDTIMEO, timeout);
 #endif
-	if (_isBrokenTimeout)
-		_sndTimeout = timeout;
+	_sndTimeout = timeout;
 }
 
 
@@ -624,16 +623,13 @@ Poco::Timespan SocketImpl::getSendTimeout()
 
 void SocketImpl::setReceiveTimeout(const Poco::Timespan& timeout)
 {
-#ifndef POCO_BROKEN_TIMEOUTS
 #if defined(_WIN32)
 	int value = (int) timeout.totalMilliseconds();
 	setOption(SOL_SOCKET, SO_RCVTIMEO, value);
 #else
 	setOption(SOL_SOCKET, SO_RCVTIMEO, timeout);
 #endif
-#endif
-	if (_isBrokenTimeout)
-		_recvTimeout = timeout;
+	_recvTimeout = timeout;
 }
 
 


### PR DESCRIPTION
Set socket timeout even in case of POCO_BROKEN_TIMEOUTS. This is needed for 3rd-party libraries (e.g. OpenSSL) to work with timeouts correctly.

Otherwise OpenSSL and LibreSSL will not be able to know about timeouts that we need.