### PR TITLE
Fix secure sockets timeouts

### DIFF
--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -213,8 +213,8 @@ public:
 		/// Returns true if the next operation corresponding to
 		/// mode will not block, false otherwise.
 
-    bool pollImpl(Poco::Timespan& timeout, int mode);
-        /// Modifies `timeout`
+	bool pollImpl(Poco::Timespan& timeout, int mode);
+		/// Modifies `timeout`
 
 	virtual void setSendBufferSize(int size);
 		/// Sets the size of the send buffer.

--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -447,7 +447,7 @@ protected:
 	static void error(int code, const std::string& arg);
 		/// Throws an appropriate exception for the given error code.
 
-private:
+protected:
 	SocketImpl(const SocketImpl&);
 	SocketImpl& operator = (const SocketImpl&);
 

--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -213,6 +213,9 @@ public:
 		/// Returns true if the next operation corresponding to
 		/// mode will not block, false otherwise.
 
+    bool pollImpl(Poco::Timespan& timeout, int mode);
+        /// Modifies `timeout`
+
 	virtual void setSendBufferSize(int size);
 		/// Sets the size of the send buffer.
 

--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -564,7 +564,7 @@ bool SocketImpl::pollImpl(Poco::Timespan& remainingTime, int mode)
 bool SocketImpl::poll(const Poco::Timespan& timeout, int mode)
 {
 	Poco::Timespan remainingTime(timeout);
-    return pollImpl(remainingTime, mode);
+	return pollImpl(remainingTime, mode);
 }
 	
 void SocketImpl::setSendBufferSize(int size)

--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -433,7 +433,7 @@ bool SocketImpl::secure() const
 }
 
 
-bool SocketImpl::poll(const Poco::Timespan& timeout, int mode)
+bool SocketImpl::pollImpl(Poco::Timespan& remainingTime, int mode)
 {
 	poco_socket_t sockfd = _sockfd;
 	if (sockfd == POCO_INVALID_SOCKET) throw InvalidSocketException();
@@ -462,7 +462,6 @@ bool SocketImpl::poll(const Poco::Timespan& timeout, int mode)
 		error("Can't insert socket to epoll queue");
 	}
 
-	Poco::Timespan remainingTime(timeout);
 	int rc;
 	do
 	{
@@ -496,7 +495,6 @@ bool SocketImpl::poll(const Poco::Timespan& timeout, int mode)
 	if (mode & SELECT_READ) pollBuf.events |= POLLIN;
 	if (mode & SELECT_WRITE) pollBuf.events |= POLLOUT;
 
-	Poco::Timespan remainingTime(timeout);
 	int rc;
 	do
 	{
@@ -537,7 +535,6 @@ bool SocketImpl::poll(const Poco::Timespan& timeout, int mode)
 	{
 		FD_SET(sockfd, &fdExcept);
 	}
-	Poco::Timespan remainingTime(timeout);
 	int errorCode = POCO_ENOERR;
 	int rc;
 	do
@@ -564,6 +561,11 @@ bool SocketImpl::poll(const Poco::Timespan& timeout, int mode)
 #endif // POCO_HAVE_FD_EPOLL
 }
 
+bool SocketImpl::poll(const Poco::Timespan& timeout, int mode)
+{
+	Poco::Timespan remainingTime(timeout);
+    return pollImpl(remainingTime, mode);
+}
 	
 void SocketImpl::setSendBufferSize(int size)
 {

--- a/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
@@ -195,7 +195,7 @@ protected:
 		/// Returns true iff the given host name is the local host
 		/// (either "localhost" or "127.0.0.1").
 
-	bool mustRetry(int rc);
+	bool mustRetry(int rc, Poco::Timespan& remaining_time);
 		/// Returns true if the last operation should be retried,
 		/// otherwise false.
 		///
@@ -220,6 +220,8 @@ protected:
 		///
 		/// Note that simply closing a socket is not sufficient
 		/// to be able to re-use it again.
+
+    Poco::Timespan getMaxTimeout();
 
 private:	
 	SecureSocketImpl(const SecureSocketImpl&);

--- a/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
@@ -221,7 +221,7 @@ protected:
 		/// Note that simply closing a socket is not sufficient
 		/// to be able to re-use it again.
 
-    Poco::Timespan getMaxTimeout();
+	Poco::Timespan getMaxTimeout();
 
 private:	
 	SecureSocketImpl(const SecureSocketImpl&);

--- a/NetSSL_OpenSSL/include/Poco/Net/SecureStreamSocketImpl.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureStreamSocketImpl.h
@@ -39,6 +39,9 @@ public:
 	SecureStreamSocketImpl(StreamSocketImpl* pStreamSocket, Context::Ptr pContext);
 		/// Creates the SecureStreamSocketImpl.
 
+    void setSendTimeout(const Poco::Timespan& timeout);
+    void setReceiveTimeout(const Poco::Timespan& timeout);
+
 	SocketImpl* acceptConnection(SocketAddress& clientAddr);
 		/// Not supported by a SecureStreamSocket.
 		///
@@ -216,6 +219,7 @@ private:
 	SecureStreamSocketImpl(const SecureStreamSocketImpl&);
 	SecureStreamSocketImpl& operator = (const SecureStreamSocketImpl&);
 
+    StreamSocketImpl * underlying_socket;
 	SecureSocketImpl _impl;
 	bool             _lazyHandshake;
 

--- a/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
@@ -119,6 +119,8 @@ void SecureSocketImpl::connect(const SocketAddress& address, const Poco::Timespa
 	poco_assert (!_pSSL);
 
 	_pSocket->connect(address, timeout);
+	//FIXME it updates timeouts of SecureStreamSocketImpl::underlying_socket it does not update timeouts of SecureStreamSocketImpl
+	//However, timeouts of SecureStreamSocketImpl are not used in connectSSL() and previous settings are restored after
 	Poco::Timespan receiveTimeout = _pSocket->getReceiveTimeout();
 	Poco::Timespan sendTimeout = _pSocket->getSendTimeout();
 	_pSocket->setReceiveTimeout(timeout);

--- a/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
@@ -44,6 +44,22 @@ using Poco::Timespan;
 namespace Poco {
 namespace Net {
 
+struct RemainingTimeCounter
+{
+	RemainingTimeCounter(Poco::Timespan& remainingTime_) : remainingTime(remainingTime_) {};
+	~RemainingTimeCounter()
+	{
+		Poco::Timestamp end;
+		Poco::Timespan waited = end - start;
+		if (waited < remainingTime)
+			remainingTime -= waited;
+		else
+			remainingTime = 0;
+	}
+private:
+	Poco::Timespan& remainingTime;
+	Poco::Timestamp start;
+};
 
 SecureSocketImpl::SecureSocketImpl(Poco::AutoPtr<SocketImpl> pSocketImpl, Context::Ptr pContext):
 	_pSSL(0),
@@ -175,7 +191,14 @@ void SecureSocketImpl::connectSSL(bool performHandshake)
 	{
 		if (performHandshake && _pSocket->getBlocking())
 		{
-			int ret = SSL_connect(_pSSL);
+			int ret;
+			Poco::Timespan remaining_time = getMaxTimeout();
+			do
+			{
+				RemainingTimeCounter counter(remaining_time);
+				ret = SSL_connect(_pSSL);
+			}
+			while (mustRetry(ret, remaining_time));
 			handleError(ret);
 			verifyPeerCertificate();
 		}
@@ -278,9 +301,10 @@ int SecureSocketImpl::sendBytes(const void* buffer, int length, int flags)
 			return rc;
 	}
 
-    Poco::Timespan remaining_time = getMaxTimeout();
+	Poco::Timespan remaining_time = getMaxTimeout();
 	do
 	{
+		RemainingTimeCounter counter(remaining_time);
 		rc = SSL_write(_pSSL, buffer, length);
 	}
 	while (mustRetry(rc, remaining_time));
@@ -308,9 +332,13 @@ int SecureSocketImpl::receiveBytes(void* buffer, int length, int flags)
 			return rc;
 	}
 
-    Poco::Timespan remaining_time = getMaxTimeout();
+	Poco::Timespan remaining_time = getMaxTimeout();
 	do
 	{
+		/// SSL record may consist of several TCP packets,
+		/// so thread can be blocked on recv/send and epoll_wait several times
+		/// until SSL_read will return rc > 0. Let's use our own time counter.
+		RemainingTimeCounter counter(remaining_time);
 		rc = SSL_read(_pSSL, buffer, length);
 	}
 	while (mustRetry(rc, remaining_time));
@@ -336,9 +364,10 @@ int SecureSocketImpl::completeHandshake()
 	poco_check_ptr (_pSSL);
 
 	int rc;
-    Poco::Timespan remaining_time = getMaxTimeout();
+	Poco::Timespan remaining_time = getMaxTimeout();
 	do
 	{
+		RemainingTimeCounter counter(remaining_time);
 		rc = SSL_do_handshake(_pSSL);
 	}
 	while (mustRetry(rc, remaining_time));
@@ -414,11 +443,11 @@ X509* SecureSocketImpl::peerCertificate() const
 
 Poco::Timespan SecureSocketImpl::getMaxTimeout()
 {
-    Poco::Timespan remaining_time = _pSocket->getReceiveTimeout();
-    Poco::Timespan send_timeout = _pSocket->getSendTimeout();
-    if (remaining_time < send_timeout)
-        remaining_time = send_timeout;
-    return remaining_time;
+	Poco::Timespan remaining_time = _pSocket->getReceiveTimeout();
+	Poco::Timespan send_timeout = _pSocket->getSendTimeout();
+	if (remaining_time < send_timeout)
+		remaining_time = send_timeout;
+	return remaining_time;
 }
 
 bool SecureSocketImpl::mustRetry(int rc, Poco::Timespan& remaining_time)
@@ -432,7 +461,9 @@ bool SecureSocketImpl::mustRetry(int rc, Poco::Timespan& remaining_time)
 		case SSL_ERROR_WANT_READ:
 			if (_pSocket->getBlocking())
 			{
-				if (_pSocket->pollImpl(remaining_time, Poco::Net::Socket::SELECT_READ))
+				/// Level-triggered mode of epoll_wait is used, so if SSL_read don't read all available data from socket,
+				/// epoll_wait returns true without waiting for new data even if remaining_time == 0
+				if (_pSocket->pollImpl(remaining_time, Poco::Net::Socket::SELECT_READ) && remaining_time != 0)
 					return true;
 				else
 					throw Poco::TimeoutException();
@@ -441,7 +472,8 @@ bool SecureSocketImpl::mustRetry(int rc, Poco::Timespan& remaining_time)
 		case SSL_ERROR_WANT_WRITE:
 			if (_pSocket->getBlocking())
 			{
-				if (_pSocket->pollImpl(remaining_time, Poco::Net::Socket::SELECT_WRITE))
+				/// The same as for SSL_ERROR_WANT_READ
+				if (_pSocket->pollImpl(remaining_time, Poco::Net::Socket::SELECT_WRITE) && remaining_time != 0)
 					return true;
 				else
 					throw Poco::TimeoutException();

--- a/NetSSL_OpenSSL/src/SecureStreamSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureStreamSocketImpl.cpp
@@ -22,14 +22,16 @@ namespace Net {
 
 
 SecureStreamSocketImpl::SecureStreamSocketImpl(Context::Ptr pContext):
-	_impl(new StreamSocketImpl, pContext),
+    underlying_socket(new StreamSocketImpl),
+	_impl(underlying_socket, pContext),
 	_lazyHandshake(false)
 {
 }
 
 
 SecureStreamSocketImpl::SecureStreamSocketImpl(StreamSocketImpl* pStreamSocket, Context::Ptr pContext):
-	_impl(pStreamSocket, pContext),
+    underlying_socket(pStreamSocket),
+	_impl(underlying_socket, pContext),
 	_lazyHandshake(false)
 {
 	pStreamSocket->duplicate();
@@ -49,6 +51,17 @@ SecureStreamSocketImpl::~SecureStreamSocketImpl()
 	}
 }
 
+void SecureStreamSocketImpl::setSendTimeout(const Poco::Timespan& timeout)
+{
+    underlying_socket->setSendTimeout(timeout);
+    _sndTimeout = underlying_socket->getSendTimeout();
+}
+
+void SecureStreamSocketImpl::setReceiveTimeout(const Poco::Timespan& timeout)
+{
+    underlying_socket->setReceiveTimeout(timeout);
+    _recvTimeout = underlying_socket->getReceiveTimeout();
+}
 
 SocketImpl* SecureStreamSocketImpl::acceptConnection(SocketAddress& clientAddr)
 {


### PR DESCRIPTION
 - When setting receive/send timeout for `SecureStreamSocketImpl`, also set it for underlying `StreamSocketImpl`, which is used by `SecureSocketImpl`. Fixes unexpected `TimeoutException` on `EINTR`.
- Use common remaining time counter for all `recv`, `send` and `epoll_wait` calls inside one `SecureStreamSocket::receiveBytes(...)` call (the same for `SecureStreamSocket::sendBytes(...)` and `SecureStreamSocket::connect(...)`). It should make timeouts more precise.
- Retry `SSL_connect` (which includes `SSL_do_handshake`) in case of `EINTR`