### PR TITLE
Set peer name properly

### DIFF
--- a/NetSSL_Win/src/HTTPSClientSession.cpp
+++ b/NetSSL_Win/src/HTTPSClientSession.cpp
@@ -146,6 +146,10 @@ void HTTPSClientSession::connect(const SocketAddress& address)
 	if (getProxyHost().empty() || bypassProxy())
 	{
 		SecureStreamSocket sss(socket());
+		if (sss.getPeerHostName().empty()) 
+		{
+			sss.setPeerHostName(getHost());
+		}
 		if (_pContext->sessionCacheEnabled())
 		{
 			sss.useSession(_pSession);

--- a/NetSSL_Win/src/SecureSocketImpl.cpp
+++ b/NetSSL_Win/src/SecureSocketImpl.cpp
@@ -700,7 +700,7 @@ void SecureSocketImpl::connectSSL(bool completeHandshake)
 
 	if (_peerHostName.empty())
 	{
-		_peerHostName = _pSocket->address().host().toString();
+		_peerHostName = _pSocket->peerAddress().host().toString();
 	}
 
 	initClientContext();
@@ -1520,7 +1520,7 @@ void SecureSocketImpl::stateIllegal()
 
 void SecureSocketImpl::stateConnected()
 {
-	_peerHostName = _pSocket->address().host().toString();
+	_peerHostName = _pSocket->peerAddress().host().toString();
 	initClientContext();
 	performInitialClientHandshake();
 }


### PR DESCRIPTION
Fix peer name passing in win ssl code, so that `ClientHello` packet contains proper server name (SNI) extension.