### PR TITLE
add <atomic> to TCPServerDispatcher

### DIFF
--- a/Net/include/Poco/Net/TCPServerDispatcher.h
+++ b/Net/include/Poco/Net/TCPServerDispatcher.h
@@ -17,6 +17,7 @@
 #ifndef Net_TCPServerDispatcher_INCLUDED
 #define Net_TCPServerDispatcher_INCLUDED
 
+#include <atomic>
 
 #include "Poco/Net/Net.h"
 #include "Poco/Net/StreamSocket.h"


### PR DESCRIPTION
```
In file included from ../contrib/poco/Net/src/TCPServerDispatcher.cpp:15:
../contrib/poco/Net/include/Poco/Net/TCPServerDispatcher.h:127:7: error: 'atomic' in namespace 'std' does not name a template type
  127 |  std::atomic<int> _rc;
      |       ^~~~~~
../contrib/poco/Net/include/Poco/Net/TCPServerDispatcher.h:27:1: note: 'std::atomic' is defined in header '<atomic>'; did you forget to '#include <atomic>'?
```

The upstream PR is https://github.com/pocoproject/poco/pull/2961