### PR TITLE
Fix thread counter leak

### DIFF
--- a/Net/include/Poco/Net/TCPServerDispatcher.h
+++ b/Net/include/Poco/Net/TCPServerDispatcher.h
@@ -101,30 +101,6 @@ private:
 	TCPServerDispatcher(const TCPServerDispatcher&);
 	TCPServerDispatcher& operator = (const TCPServerDispatcher&);
 
-	class ThreadCountWatcher
-	{
-	public:
-		ThreadCountWatcher(TCPServerDispatcher* pDisp) : _pDisp(pDisp)
-		{
-		}
-
-		~ThreadCountWatcher()
-		{
-			FastMutex::ScopedLock lock(_pDisp->_mutex);
-			if (_pDisp->_currentThreads > 1 && _pDisp->_queue.empty())
-			{
-				--_pDisp->_currentThreads;
-			}
-		}
-
-		private:
-			ThreadCountWatcher();
-			ThreadCountWatcher(const ThreadCountWatcher&);
-			ThreadCountWatcher& operator=(const ThreadCountWatcher&);
-
-			TCPServerDispatcher* _pDisp;
-	};
-
 	std::atomic<int> _rc;
 	TCPServerParams::Ptr _pParams;
 	std::atomic<int>  _currentThreads;

--- a/Net/src/TCPServerDispatcher.cpp
+++ b/Net/src/TCPServerDispatcher.cpp
@@ -98,29 +98,31 @@ void TCPServerDispatcher::run()
 
 	for (;;)
 	{
+		try
 		{
-			ThreadCountWatcher tcw(this);
-			try
+			AutoPtr<Notification> pNf = _queue.waitDequeueNotification(idleTime);
+			if (pNf)
 			{
-				AutoPtr<Notification> pNf = _queue.waitDequeueNotification(idleTime);
-				if (pNf)
+				TCPConnectionNotification* pCNf = dynamic_cast<TCPConnectionNotification*>(pNf.get());
+				if (pCNf)
 				{
-					TCPConnectionNotification* pCNf = dynamic_cast<TCPConnectionNotification*>(pNf.get());
-					if (pCNf)
-					{
-						std::unique_ptr<TCPServerConnection> pConnection(_pConnectionFactory->createConnection(pCNf->socket()));
-						poco_check_ptr(pConnection.get());
-						beginConnection();
-						pConnection->start();
-						endConnection();
-					}
+					std::unique_ptr<TCPServerConnection> pConnection(_pConnectionFactory->createConnection(pCNf->socket()));
+					poco_check_ptr(pConnection.get());
+					beginConnection();
+					pConnection->start();
+					endConnection();
 				}
 			}
-			catch (Poco::Exception &exc) { ErrorHandler::handle(exc); }
-			catch (std::exception &exc)  { ErrorHandler::handle(exc); }
-			catch (...)                  { ErrorHandler::handle();    }
 		}
-		if (_stopped || (_currentThreads > 1 && _queue.empty())) break;
+		catch (Poco::Exception &exc) { ErrorHandler::handle(exc); }
+		catch (std::exception &exc)  { ErrorHandler::handle(exc); }
+		catch (...)                  { ErrorHandler::handle();    }
+		FastMutex::ScopedLock lock(_mutex);
+		if (_stopped || (_currentThreads > 1 && _queue.empty()))
+		{
+			--_currentThreads;
+			break;
+		}
 	}
 }
 


### PR DESCRIPTION
This issue has appeared three times in kuaishou (every 1-2 months). TCPServerDispatcher fails to create any new threads because `_currentThreads` is leaked.

The issue is introduced in https://github.com/pocoproject/poco/pull/1965 which was actual to fix another `_currentThreads` leaking issue...  However I cannot find the related commit in current poco's master or develop branch. Perhaps it's already been reverted.