### PR TITLE
Fix potentially unsafe code

### DIFF
--- a/Foundation/src/Unicode.cpp
+++ b/Foundation/src/Unicode.cpp
@@ -27,7 +27,7 @@ namespace Poco {
 
 void Unicode::properties(int ch, CharacterProperties& props)
 {
-	if (ch > UCP_MAX_CODEPOINT) ch = 0;
+	if (ch < 0 || ch > UCP_MAX_CODEPOINT) ch = 0;
 	const ucd_record* ucd = GET_UCD(ch);
 	props.category = static_cast<CharacterCategory>(_pcre_ucp_gentype[ucd->chartype]);
 	props.type     = static_cast<CharacterType>(ucd->chartype);


### PR DESCRIPTION
So many times people use `int` for array index in various libraries...