### PR TITLE
Set SOCK_CLOEXOEC for sockets

### DIFF
--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -946,7 +946,7 @@ int SocketImpl::socketError()
 
 void SocketImpl::init(int af)
 {
-	initSocket(af, SOCK_STREAM);
+	initSocket(af, SOCK_STREAM|SOCK_CLOEXEC);
 }
 
 


### PR DESCRIPTION
I've tried to do a normal interface, with ability to set it optinally,
but it is not that trivial, anyway creating socket w/o SOCK_CLOEXEC is
almost always an error (it is not a pipe/socketpair that may be used to
shared data between child and parent).

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/9174