### PR TITLE
Use SOCK_CLOEXEC only if it is availabie (fixes osx build)

### DIFF
--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -946,7 +946,11 @@ int SocketImpl::socketError()
 
 void SocketImpl::init(int af)
 {
+#ifdef SOCK_CLOEXEC
 	initSocket(af, SOCK_STREAM|SOCK_CLOEXEC);
+#else
+	initSocket(af, SOCK_STREAM);
+#endif
 }
 
 


### PR DESCRIPTION
Fixes: #35 