### PR TITLE
Do not throw if there is space in URI because it is anyway encoded later

### DIFF
--- a/Foundation/src/URI.cpp
+++ b/Foundation/src/URI.cpp
@@ -720,8 +720,8 @@ unsigned short URI::getWellKnownPort() const
 void URI::parse(const std::string& uri)
 {
 	std::for_each(uri.begin(), uri.end(), [] (char ch) {
-		if (static_cast<signed char>(ch) <= 32 || ch == '\x7F')
-			throw URISyntaxException("URI contains invalid characters");
+		if ((!std::isspace(ch) && static_cast<signed char>(ch) <= 32) || (ch == '\x7F'))
+			throw URISyntaxException("URI contains invalid characters: " + ch);
 	});
 
 	std::string::const_iterator it  = uri.begin();


### PR DESCRIPTION
It throws in case there are spaces in passed uri, but it will anyway be encoded later and it works correctly if allowing spaces.
This is needed to pass file names with spaces to hdfs. Checked it works correctly after this fix with these files:
> bash-4.1# hadoop fs -mkdir /test   
bash-4.1# hdfs dfs -put kssenii.txt '/test/test test test 0.txt'
bash-4.1# hdfs dfs -put kssenii.txt '/test/test test test 1.txt'
bash-4.1# hdfs dfs -put kssenii.txt '/test/test test test 2.txt'
bash-4.1# hadoop fs -ls /test   
Found 3 items
-rw-r--r--   1 root supergroup        292 2021-04-17 07:31 /test/test test test 0.txt
-rw-r--r--   1 root supergroup        292 2021-04-17 07:31 /test/test test test 1.txt
-rw-r--r--   1 root supergroup        292 2021-04-17 07:31 /test/test test test 2.txt

Changing spaces to '+' or '%20' does not help because it will be encoded anyway.