### PR TITLE
Adds support for building on illumos

### DIFF
--- a/Net/src/PollSet.cpp
+++ b/Net/src/PollSet.cpp
@@ -34,6 +34,8 @@
 #elif defined(POCO_HAVE_FD_POLL)
 #ifndef _WIN32
 #include <poll.h>
+#elif __sun
+#include <cstring>
 #endif
 #endif
 


### PR DESCRIPTION
This is part of a larger set of changes for supporting ClickHouse on [illumos](https://illumos.org).

On illumos, the `FD_ZERO` macro is implemented in terms of `memset(3C)`, which is defined in the `cstring` header.