### PR TITLE
Use poll() over epoll() for SocketImpl::poll() (7x+ faster)

### DIFF
--- a/Net/testsuite/src/SocketTest.cpp
+++ b/Net/testsuite/src/SocketTest.cpp
@@ -89,6 +89,20 @@ void SocketTest::testPoll()
 }
 
 
+void SocketTest::testPollStress()
+{
+	EchoServer echoServer;
+	StreamSocket ss;
+	ss.connect(SocketAddress("127.0.0.1", echoServer.port()));
+	Stopwatch sw;
+	for (size_t i = 0; i < 1'000'000; ++i)
+	{
+		sw.restart();
+		assert (ss.poll(1, Socket::SELECT_WRITE));
+	}
+}
+
+
 void SocketTest::testAvailable()
 {
 	EchoServer echoServer;
@@ -560,6 +574,7 @@ CppUnit::Test* SocketTest::suite()
 
 	CppUnit_addTest(pSuite, SocketTest, testEcho);
 	CppUnit_addTest(pSuite, SocketTest, testPoll);
+	CppUnit_addTest(pSuite, SocketTest, testPollStress);
 	CppUnit_addTest(pSuite, SocketTest, testAvailable);
 	CppUnit_addTest(pSuite, SocketTest, testFIFOBuffer);
 	CppUnit_addTest(pSuite, SocketTest, testConnect);

--- a/Net/testsuite/src/SocketTest.h
+++ b/Net/testsuite/src/SocketTest.h
@@ -26,6 +26,7 @@ public:
 
 	void testEcho();
 	void testPoll();
+	void testPollStress();
 	void testAvailable();
 	void testFIFOBuffer();
 	void testConnect();


### PR DESCRIPTION
It does not makes any sense in using epoll there since epoll fd created
every time SocketImpl::poll() is called, and this has higher overhead:

- **before** this patch: `testPollStress` takes **~3sec**
- **after** this patch: `testPollStress` takes **~0.4sec**