### PR TITLE
try to fix stack-use-after-scope

### DIFF
--- a/Foundation/include/Poco/DirectoryWatcher.h
+++ b/Foundation/include/Poco/DirectoryWatcher.h
@@ -185,12 +185,12 @@ private:
 	DirectoryWatcher(const DirectoryWatcher&);
 	DirectoryWatcher& operator = (const DirectoryWatcher&);
 
-	Thread _thread;
 	File _directory;
 	int _eventMask;
 	AtomicCounter _eventsSuspended;
 	int _scanInterval;
 	std::shared_ptr<DirectoryWatcherStrategy> _pStrategy;
+	Thread _thread;
 };
 
 

--- a/Foundation/include/Poco/DirectoryWatcher.h
+++ b/Foundation/include/Poco/DirectoryWatcher.h
@@ -30,6 +30,7 @@
 #include "Poco/Thread.h"
 #include "Poco/AtomicCounter.h"
 
+#    include <memory>
 
 namespace Poco {
 
@@ -189,7 +190,7 @@ private:
 	int _eventMask;
 	AtomicCounter _eventsSuspended;
 	int _scanInterval;
-	DirectoryWatcherStrategy* _pStrategy;
+    std::shared_ptr<DirectoryWatcherStrategy> _pStrategy;
 };
 
 

--- a/Foundation/include/Poco/DirectoryWatcher.h
+++ b/Foundation/include/Poco/DirectoryWatcher.h
@@ -30,7 +30,7 @@
 #include "Poco/Thread.h"
 #include "Poco/AtomicCounter.h"
 
-#    include <memory>
+#include <memory>
 
 namespace Poco {
 
@@ -190,7 +190,7 @@ private:
 	int _eventMask;
 	AtomicCounter _eventsSuspended;
 	int _scanInterval;
-    std::shared_ptr<DirectoryWatcherStrategy> _pStrategy;
+	std::shared_ptr<DirectoryWatcherStrategy> _pStrategy;
 };
 
 

--- a/Foundation/src/DirectoryWatcher.cpp
+++ b/Foundation/src/DirectoryWatcher.cpp
@@ -299,8 +299,8 @@ public:
 		}
 		
 		Poco::Buffer<char> buffer(4096);
-		while (!_stopped.load(std::memory_order_relaxed))
-		{
+        while (!_stopped)
+        {
 			FD_ZERO(&fds);
 			FD_SET(_fd, &fds);
 
@@ -365,7 +365,7 @@ public:
 	
 	void stop()
 	{
-		_stopped.store(true, std::memory_order_relaxed);
+		_stopped = true;
 	}
 	
 	bool supportsMoveEvents() const

--- a/Foundation/src/DirectoryWatcher.cpp
+++ b/Foundation/src/DirectoryWatcher.cpp
@@ -301,7 +301,6 @@ public:
 		Poco::Buffer<char> buffer(4096);
 		while (!_stopped.load(std::memory_order_relaxed))
 		{
-			fd_set fds;
 			FD_ZERO(&fds);
 			FD_SET(_fd, &fds);
 
@@ -376,6 +375,7 @@ public:
 
 private:
 	int _fd;
+	fd_set fds;
 	std::atomic<bool> _stopped;
 };
 

--- a/Foundation/src/DirectoryWatcher.cpp
+++ b/Foundation/src/DirectoryWatcher.cpp
@@ -299,8 +299,8 @@ public:
 		}
 		
 		Poco::Buffer<char> buffer(4096);
-        while (!_stopped)
-        {
+		while (!_stopped)
+		{
 			FD_ZERO(&fds);
 			FD_SET(_fd, &fds);
 
@@ -570,14 +570,14 @@ void DirectoryWatcher::init()
 		throw Poco::InvalidArgumentException("not a directory", _directory.path());
 
 #if POCO_OS == POCO_OS_WINDOWS_NT
-    _pStrategy = std::make_shared<WindowsDirectoryWatcherStrategy>(*this);
-#    elif POCO_OS == POCO_OS_LINUX || POCO_OS == POCO_OS_ANDROID
-    _pStrategy = std::make_shared<LinuxDirectoryWatcherStrategy>(*this);
-#    elif POCO_OS == POCO_OS_MAC_OS_X || POCO_OS == POCO_OS_FREE_BSD
-    _pStrategy = std::make_shared<BSDDirectoryWatcherStrategy>(*this);
-#    else
-    _pStrategy = std::make_shared<PollingDirectoryWatcherStrategy>(*this);
-#    endif
+	_pStrategy = std::make_shared<WindowsDirectoryWatcherStrategy>(*this);
+#elif POCO_OS == POCO_OS_LINUX || POCO_OS == POCO_OS_ANDROID
+	_pStrategy = std::make_shared<LinuxDirectoryWatcherStrategy>(*this);
+#elif POCO_OS == POCO_OS_MAC_OS_X || POCO_OS == POCO_OS_FREE_BSD
+	_pStrategy = std::make_shared<BSDDirectoryWatcherStrategy>(*this);
+#else
+	_pStrategy = std::make_shared<PollingDirectoryWatcherStrategy>(*this);
+#endif
 	_thread.start(*this);
 }
 

--- a/Foundation/src/DirectoryWatcher.cpp
+++ b/Foundation/src/DirectoryWatcher.cpp
@@ -539,7 +539,6 @@ DirectoryWatcher::~DirectoryWatcher()
 	try
 	{
 		stop();
-		delete _pStrategy;
 	}
 	catch (...)
 	{
@@ -571,14 +570,14 @@ void DirectoryWatcher::init()
 		throw Poco::InvalidArgumentException("not a directory", _directory.path());
 
 #if POCO_OS == POCO_OS_WINDOWS_NT
-	_pStrategy = new WindowsDirectoryWatcherStrategy(*this);
-#elif POCO_OS == POCO_OS_LINUX || POCO_OS == POCO_OS_ANDROID
-	_pStrategy = new LinuxDirectoryWatcherStrategy(*this);
-#elif POCO_OS == POCO_OS_MAC_OS_X || POCO_OS == POCO_OS_FREE_BSD
-	_pStrategy = new BSDDirectoryWatcherStrategy(*this);
-#else
-	_pStrategy = new PollingDirectoryWatcherStrategy(*this);
-#endif
+    _pStrategy = std::make_shared<WindowsDirectoryWatcherStrategy>(*this);
+#    elif POCO_OS == POCO_OS_LINUX || POCO_OS == POCO_OS_ANDROID
+    _pStrategy = std::make_shared<LinuxDirectoryWatcherStrategy>(*this);
+#    elif POCO_OS == POCO_OS_MAC_OS_X || POCO_OS == POCO_OS_FREE_BSD
+    _pStrategy = std::make_shared<BSDDirectoryWatcherStrategy>(*this);
+#    else
+    _pStrategy = std::make_shared<PollingDirectoryWatcherStrategy>(*this);
+#    endif
 	_thread.start(*this);
 }
 

--- a/Foundation/src/DirectoryWatcher.cpp
+++ b/Foundation/src/DirectoryWatcher.cpp
@@ -299,6 +299,7 @@ public:
 		}
 		
 		Poco::Buffer<char> buffer(4096);
+		fd_set fds;
 		while (!_stopped)
 		{
 			FD_ZERO(&fds);
@@ -375,7 +376,6 @@ public:
 
 private:
 	int _fd;
-	fd_set fds;
 	std::atomic<bool> _stopped;
 };
 


### PR DESCRIPTION
https://clickhouse-test-reports.s3.yandex.net/25969/127a0f35910a097b5240d68cc60f5e30b9e697ac/stress_test_(address)/stderr.log
```
==534==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7f491e557ef0 at pc 0x00002e04e01d bp 0x7f491e557d30 sp 0x7f491e557d28
READ of size 8 at 0x7f491e557ef0 thread T830
    #0 0x2e04e01c in Poco::LinuxDirectoryWatcherStrategy::run() obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/DirectoryWatcher.cpp:306:4
    #1 0x2e17fd39 in Poco::ThreadImpl::runnableEntry(void*) obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread_POSIX.cpp:345:27
    #2 0x7f4c06254608 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x9608)
    #3 0x7f4c0617b292 in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x122292)

Address 0x7f491e557ef0 is located in stack of thread T830 at offset 240 in frame
    #0 0x2e04d16f in Poco::LinuxDirectoryWatcherStrategy::run() obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/DirectoryWatcher.cpp:276

  This frame has 11 object(s):
    [32, 160) 'fds' (line 304)
    [192, 208) 'tv' (line 308)
    [224, 352) 'p' (line 326) <== Memory access at offset 240 is inside this variable
    [384, 408) 'ref.tmp' (line 328)
    [448, 480) 'f' (line 329)
    [512, 536) 'ref.tmp103' (line 329)
    [576, 592) 'ev' (line 333)
    [608, 624) 'ev141' (line 338)
    [640, 656) 'ev162' (line 343)
    [672, 688) 'ev183' (line 348)
    [704, 720) 'ev204' (line 353)
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
Thread T830 created by T256 (TCPHandler) here:
==534==unpoisoning: 0x7f4b34518360 20
==534==unpoisoning: 0x7f4b34518300 10
==534==unpoisoning: 0x7f4b345181e0 d0
==534==unpoisoning: 0x7f4b34518180 18
==534==poisoning: 0x7f4b34518180 18
==534==unpoisoning: 0x7f4b34518100 28
==534==unpoisoning: 0x7f4b345180a0 10
==534==unpoisoning: 0x7f4b34518040 18
==534==unpoisoning: 0x7f4b34517fe0 10
==534==unpoisoning: 0x7f4b34517f80 18
==534==unpoisoning: 0x7f4b34518420 1
==534==poisoning: 0x7f4b34518420 1
==534==poisoning: 0x7f4b34517f80 18
==534==poisoning: 0x7f4b34517fe0 10
==534==poisoning: 0x7f4b34518040 18
==534==unpoisoning: 0x7f4b34517e60 10
==534==unpoisoning: 0x7f4b345184e0 10
==534==poisoning: 0x7f4b345184e0 10
==534==poisoning: 0x7f4b34517e60 10
==534==poisoning: 0x7f4b345180a0 10
==534==poisoning: 0x7f4b34518100 28
==534==poisoning: 0x7f4b345181e0 d0
==534==poisoning: 0x7f4b34518300 10
==534==poisoning: 0x7f4b34518360 20
    #0 0xb7b9fdc in pthread_create (/usr/bin/clickhouse+0xb7b9fdc)
    #1 0x2e17f10a in Poco::ThreadImpl::startImpl(Poco::SharedPtr<Poco::Runnable, Poco::ReferenceCounter, Poco::ReleasePolicy<Poco::Runnable> >) obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread_POSIX.cpp:202:6
    #2 0x2e181f5d in Poco::Thread::start(Poco::Runnable&) obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread.cpp:128:2
    #3 0x2e04b83c in Poco::DirectoryWatcher::init() obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/DirectoryWatcher.cpp:582:10
    #4 0x2e04b412 in Poco::DirectoryWatcher::DirectoryWatcher(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int) obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/DirectoryWatcher.cpp:524:2
    #5 0x25d2c836 in std::__1::__unique_if<Poco::DirectoryWatcher>::__unique_single std::__1::make_unique<Poco::DirectoryWatcher, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) obj-x86_64-linux-gnu/../contrib/libcxx/include/memory:2068:32
    #6 0x25d2c836 in FileLogDirectoryWatcher::FileLogDirectoryWatcher(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) obj-x86_64-linux-gnu/../src/Storages/FileLog/FileLogDirectoryWatcher.cpp:6:23
    #7 0x25cf76a6 in std::__1::__unique_if<FileLogDirectoryWatcher>::__unique_single std::__1::make_unique<FileLogDirectoryWatcher, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) obj-x86_64-linux-gnu/../contrib/libcxx/include/memory:2068:32
    #8 0x25cf76a6 in DB::StorageFileLog::StorageFileLog(DB::StorageID const&, std::__1::shared_ptr<DB::Context const>, DB::ColumnsDescription const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::unique_ptr<DB::FileLogSettings, std::__1::default_delete<DB::FileLogSettings> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) obj-x86_64-linux-gnu/../src/Storages/FileLog/StorageFileLog.cpp:90:31
    #9 0x25d1c376 in std::__1::shared_ptr<DB::StorageFileLog> shared_ptr_helper<DB::StorageFileLog>::create<DB::StorageID const&, std::__1::shared_ptr<DB::Context>, DB::ColumnsDescription const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::unique_ptr<DB::FileLogSettings, std::__1::default_delete<DB::FileLogSettings> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool const&>(DB::StorageID const&, std::__1::shared_ptr<DB::Context>&&, DB::ColumnsDescription const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::unique_ptr<DB::FileLogSettings, std::__1::default_delete<DB::FileLogSettings> >&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool const&) obj-x86_64-linux-gnu/../base/base/../base/shared_ptr_helper.h:17:39
    #10 0x25d1c376 in DB::registerStorageFileLog(DB::StorageFactory&)::$_2::operator()(DB::StorageFactory::Arguments const&) const obj-x86_64-linux-gnu/../src/Storages/FileLog/StorageFileLog.cpp:736:16
    #11 0x25d1c376 in decltype(std::__1::forward<DB::registerStorageFileLog(DB::StorageFactory&)::$_2&>(fp)(std::__1::forward<DB::StorageFactory::Arguments const&>(fp0))) std::__1::__invoke<DB::registerStorageFileLog(DB::StorageFactory&)::$_2&, DB::StorageFactory:
```

This may does not work, I think it's a false positive, and I don't see anythins wrong with it.