### PR TITLE
Fix riscv support

### DIFF
--- a/Foundation/src/utils.h
+++ b/Foundation/src/utils.h
@@ -62,7 +62,8 @@
     defined(__sparc__) || defined(__sparc) || defined(__s390__) || \
     defined(__SH4__) || defined(__alpha__) || \
     defined(_MIPS_ARCH_MIPS32R2) || \
-    defined(__AARCH64EL__) || \
+    defined(__riscv) || \
+	defined(__AARCH64EL__) || \
     defined(nios2) || defined(__nios2) || defined(__nios2__)
 #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1
 #elif defined(_M_IX86) || defined(__i386__) || defined(__i386)


### PR DESCRIPTION
It seems that https://github.com/pocoproject/poco/commit/26fa1b9e6bbe3a5d2d559d0e8bd5772a4e8fdfef
was not fully applied (only Platform.h changes were there).

Grab also part of the commit that modified src/utils.h