### PR TITLE
Update mongo

### DIFF
--- a/MongoDB/src/Database.cpp
+++ b/MongoDB/src/Database.cpp
@@ -45,7 +45,7 @@ namespace
 	std::map<std::string, std::string> parseKeyValueList(const std::string& str)
 	{
 		std::map<std::string, std::string> kvm;
-		std::string::const_iterator it = str.begin(); 
+		std::string::const_iterator it = str.begin();
 		std::string::const_iterator end = str.end();
 		while (it != end)
 		{
@@ -68,7 +68,7 @@ namespace
 		Poco::StreamCopier::copyToString(decoder, result);
 		return result;
 	}
-	
+
 	std::string encodeBase64(const std::string& data)
 	{
 		std::ostringstream ostr;
@@ -135,8 +135,8 @@ bool Database::authenticate(Connection& connection, const std::string& username,
 {
 	if (username.empty()) throw Poco::InvalidArgumentException("empty username");
 	if (password.empty()) throw Poco::InvalidArgumentException("empty password");
-	
-	if (method == AUTH_MONGODB_CR) 
+
+	if (method == AUTH_MONGODB_CR)
 		return authCR(connection, username, password);
 	else if (method == AUTH_SCRAM_SHA1)
 		return authSCRAM(connection, username, password);
@@ -169,13 +169,13 @@ bool Database::authCR(Connection& connection, const std::string& username, const
 	md5.update(username);
 	md5.update(credsDigest);
 	std::string key = digestToHexString(md5);
-	
+
 	pCommand = createCommand();
 	pCommand->selector()
 		.add<Poco::Int32>("authenticate", 1)
 		.add<std::string>("user", username)
 		.add<std::string>("nonce", nonce)
-		.add<std::string>("key", key); 
+		.add<std::string>("key", key);
 
 	connection.sendRequest(*pCommand, response);
 	if (response.documents().size() > 0)
@@ -191,20 +191,19 @@ bool Database::authSCRAM(Connection& connection, const std::string& username, co
 {
 	std::string clientNonce(createNonce());
 	std::string clientFirstMsg = Poco::format("n=%s,r=%s", username, clientNonce);
-	
+
 	Poco::SharedPtr<QueryRequest> pCommand = createCommand();
 	pCommand->selector()
 		.add<Poco::Int32>("saslStart", 1)
 		.add<std::string>("mechanism", AUTH_SCRAM_SHA1)
-		.add<Binary::Ptr>("payload", new Binary(Poco::format("n,,%s", clientFirstMsg)))
-		.add<bool>("authAuthorize", true); 
-		
+		.add<Binary::Ptr>("payload", new Binary(Poco::format("n,,%s", clientFirstMsg)));
+
 	ResponseMessage response;
 	connection.sendRequest(*pCommand, response);
-	
+
 	Int32 conversationId = 0;
 	std::string serverFirstMsg;
-	
+
 	if (response.documents().size() > 0)
 	{
 		Document::Ptr pDoc = response.documents()[0];
@@ -214,10 +213,20 @@ bool Database::authSCRAM(Connection& connection, const std::string& username, co
 			serverFirstMsg = pPayload->toRawString();
 			conversationId = pDoc->get<Int32>("conversationId");
 		}
-		else return false;
+		else
+		{
+			if (pDoc->exists("errmsg"))
+			{
+				const Poco::MongoDB::Element::Ptr value = pDoc->get("errmsg");
+				auto message = static_cast<const Poco::MongoDB::ConcreteElement<std::string> &>(*value).value();
+				throw Poco::RuntimeException(message);
+			}
+			else
+				return false;
+		}
 	}
 	else throw Poco::ProtocolException("empty response for saslStart");
-	
+
 	std::map<std::string, std::string> kvm = parseKeyValueList(serverFirstMsg);
 	const std::string serverNonce = kvm["r"];
 	const std::string salt = decodeBase64(kvm["s"]);
@@ -225,40 +234,40 @@ bool Database::authSCRAM(Connection& connection, const std::string& username, co
 	const Poco::UInt32 dkLen = 20;
 
 	std::string hashedPassword = hashCredentials(username, password);
-		
+
 	Poco::PBKDF2Engine<Poco::HMACEngine<Poco::SHA1Engine> > pbkdf2(salt, iterations, dkLen);
 	pbkdf2.update(hashedPassword);
 	std::string saltedPassword = digestToBinaryString(pbkdf2);
-	
+
 	std::string clientFinalNoProof = Poco::format("c=biws,r=%s", serverNonce);
 	std::string authMessage = Poco::format("%s,%s,%s", clientFirstMsg, serverFirstMsg, clientFinalNoProof);
-	
+
 	Poco::HMACEngine<Poco::SHA1Engine> hmacKey(saltedPassword);
 	hmacKey.update(std::string("Client Key"));
 	std::string clientKey = digestToBinaryString(hmacKey);
-	
+
 	Poco::SHA1Engine sha1;
 	sha1.update(clientKey);
 	std::string storedKey = digestToBinaryString(sha1);
-	
+
 	Poco::HMACEngine<Poco::SHA1Engine> hmacSig(storedKey);
 	hmacSig.update(authMessage);
 	std::string clientSignature = digestToBinaryString(hmacSig);
-	
+
 	std::string clientProof(clientKey);
 	for (std::size_t i = 0; i < clientProof.size(); i++)
 	{
 		clientProof[i] ^= clientSignature[i];
 	}
-	
+
 	std::string clientFinal = Poco::format("%s,p=%s", clientFinalNoProof, encodeBase64(clientProof));
-	
+
 	pCommand = createCommand();
 	pCommand->selector()
 		.add<Poco::Int32>("saslContinue", 1)
 		.add<Poco::Int32>("conversationId", conversationId)
 		.add<Binary::Ptr>("payload", new Binary(clientFinal));
-	
+
 	std::string serverSecondMsg;
 	connection.sendRequest(*pCommand, response);
 	if (response.documents().size() > 0)
@@ -269,24 +278,34 @@ bool Database::authSCRAM(Connection& connection, const std::string& username, co
 			Binary::Ptr pPayload = pDoc->get<Binary::Ptr>("payload");
 			serverSecondMsg = pPayload->toRawString();
 		}
-		else return false;
+		else
+		{
+			if (pDoc->exists("errmsg"))
+			{
+				const Poco::MongoDB::Element::Ptr value = pDoc->get("errmsg");
+				auto message = static_cast<const Poco::MongoDB::ConcreteElement<std::string> &>(*value).value();
+				throw Poco::RuntimeException(message);
+			}
+			else
+				return false;
+		}
 	}
 	else throw Poco::ProtocolException("empty response for saslContinue");
 
 	Poco::HMACEngine<Poco::SHA1Engine> hmacSKey(saltedPassword);
 	hmacSKey.update(std::string("Server Key"));
 	std::string serverKey = digestToBinaryString(hmacSKey);
-	
+
 	Poco::HMACEngine<Poco::SHA1Engine> hmacSSig(serverKey);
 	hmacSSig.update(authMessage);
 	std::string serverSignature = digestToBase64(hmacSSig);
-	
+
 	kvm = parseKeyValueList(serverSecondMsg);
 	std::string serverSignatureReceived = kvm["v"];
-	
-	if (serverSignature != serverSignatureReceived) 	
+
+	if (serverSignature != serverSignatureReceived)
 		throw Poco::ProtocolException("server signature verification failed");
-	
+
 	pCommand = createCommand();
 	pCommand->selector()
 		.add<Poco::Int32>("saslContinue", 1)
@@ -297,7 +316,21 @@ bool Database::authSCRAM(Connection& connection, const std::string& username, co
 	if (response.documents().size() > 0)
 	{
 		Document::Ptr pDoc = response.documents()[0];
-		return pDoc->getInteger("ok") == 1;
+		if (pDoc->getInteger("ok") == 1)
+		{
+			return true;
+		}
+		else
+		{
+			if (pDoc->exists("errmsg"))
+			{
+				const Poco::MongoDB::Element::Ptr value = pDoc->get("errmsg");
+				auto message = static_cast<const Poco::MongoDB::ConcreteElement<std::string> &>(*value).value();
+				throw Poco::RuntimeException(message);
+			}
+			else
+				return false;
+		}
 	}
 	else throw Poco::ProtocolException("empty response for saslContinue");
 }


### PR DESCRIPTION
Removed `authAuthorize=1` option. It is lnot even present in specification: https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst#scram-sha-1 (but all other options are mentioned in this specification).
All other options apart from this one, are present in specification. There was an error `BSON field 'saslStart.authAuthorize' is an unknown field`. But it was not thrown anyhow or logged anywhere, so also added a way to see actual error reason by throwing an exception instead of returning false as an indicator that failed to connect.

After removing it, mongodb engine is able to connect to 5.0 version of mongo successfully. Also checked earlier versions -- it is still able to connect after this change.