### PR TITLE
Fix virtual-class-destructor issue during clang-tidy scan

### DIFF
--- a/Util/include/Poco/Util/AbstractConfiguration.h
+++ b/Util/include/Poco/Util/AbstractConfiguration.h
@@ -356,7 +356,7 @@ protected:
 	static bool parseBool(const std::string& value);
 	void setRawWithEvent(const std::string& key, std::string value);
 	
-	virtual ~AbstractConfiguration();
+	~AbstractConfiguration();
 
 private:
 	std::string internalExpand(const std::string& value) const;


### PR DESCRIPTION
cppcoreguidelines-virtual-class-destructor
https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-virtual-class-destructor.html

http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-dtor-virtual
C.35: A base class destructor should be either public and virtual, or protected and non-virtual
Reason To prevent undefined behavior