### PR TITLE
Fix socket poll() with negative timeout (breaks poll() on EINTR)

### DIFF
--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -470,7 +470,11 @@ bool SocketImpl::pollImpl(Poco::Timespan& remainingTime, int mode)
 #else
 		rc = ::poll(&pollBuf, 1, remainingTime.totalMilliseconds());
 #endif
-		if (rc < 0 && lastError() == POCO_EINTR)
+		/// Decrease timeout in case of retriable error.
+		///
+		/// But do this only if the timeout is positive,
+		/// since negative timeout means an infinite timeout.
+		if (rc < 0 && lastError() == POCO_EINTR && remainingTime > 0)
 		{
 			Poco::Timestamp end;
 			Poco::Timespan waited = end - start;


### PR DESCRIPTION
In case of EINTR the timeout will be adjusted, but this should not be
done in case of negative timeout since it means infinite timeout, and
in that adjustment block negative timeout will be reset to 0, which will
make poll() return (since zero timeout means return immediatelly even if
no fd is ready).