### PR TITLE
Do not add default port for requests via proxy (fixes GCS via proxy tunnel usage)

### DIFF
--- a/Net/src/HTTPClientSession.cpp
+++ b/Net/src/HTTPClientSession.cpp
@@ -429,8 +429,13 @@ std::string HTTPClientSession::proxyRequestPrefix() const
 {
 	std::string result("http://");
 	result.append(_host);
-	result.append(":");
-	NumberFormatter::append(result, _port);
+	/// Do not append default by default, since this may break some servers.
+	/// One example of such server is GCS (Google Cloud Storage).
+	if (_port != HTTPSession::HTTP_PORT)
+	{
+		result.append(":");
+		NumberFormatter::append(result, _port);
+	}
 	return result;
 }
 

--- a/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
@@ -138,8 +138,13 @@ std::string HTTPSClientSession::proxyRequestPrefix() const
 {
 	std::string result("https://");
 	result.append(getHost());
-	result.append(":");
-	NumberFormatter::append(result, getPort());
+	/// Do not append default by default, since this may break some servers.
+	/// One example of such server is GCS (Google Cloud Storage).
+	if (getPort() != HTTPS_PORT)
+	{
+		result.append(":");
+		NumberFormatter::append(result, getPort());
+	}
 	return result;
 }
 


### PR DESCRIPTION
GCS server does not handle requests with port, and simply report an
error:

```xml
    <?xml version="1.0"?>
    <?xml version='1.0' encoding='UTF-8'?>
    <Error>
        <Code>InvalidURI</Code>
        <Message>Couldn't parse the specified URI.</Message>
        <Details>Invalid URL: storage.googleapis.com:443/...</Details>
    </Error>
```

Removing the port fixes the issue. Note that there is port in the Host
header anyway.

Note, this is a problem only for proxy in a tunnel mode, since only it
sends such requests, other sends requests directly via HTTP methods.

Refs: #22 (cc @Jokser)
Refs: https://github.com/ClickHouse/ClickHouse/pull/38069 (cc @CurtizJ )
Cc: @alesapin @kssenii 