### PR TITLE
Fix empty files creation when rotating on full disk

### DIFF
--- a/Foundation/src/LogFile_STD.cpp
+++ b/Foundation/src/LogFile_STD.cpp
@@ -55,6 +55,8 @@ void LogFileImpl::writeBinaryImpl(const char * data, size_t size, bool flush)
 
 UInt64 LogFileImpl::sizeImpl() const
 {
+	if (!_str.good())
+        	throw FileException(_path);
 	return (UInt64) _str.tellp();
 }
 


### PR DESCRIPTION
Fix for https://github.com/ClickHouse/ClickHouse/issues/37766