### PR TITLE
Use unordered_map from key to count instead of multiset

### DIFF
--- a/Util/src/XMLConfiguration.cpp
+++ b/Util/src/XMLConfiguration.cpp
@@ -265,8 +265,8 @@ void XMLConfiguration::setRaw(const std::string& key, const std::string& value)
 void XMLConfiguration::enumerate(const std::string& key, Keys& range) const
 {
 	using Poco::NumberFormatter;
-	
-	std::multiset<std::string> keys;
+
+	std::unordered_map<std::string, size_t> keys;
 	const Poco::XML::Node* pNode = findNode(key);
 	if (pNode)
 	{
@@ -276,12 +276,12 @@ void XMLConfiguration::enumerate(const std::string& key, Keys& range) const
 			if (pChild->nodeType() == Poco::XML::Node::ELEMENT_NODE)
 			{
 				const std::string& nodeName = pChild->nodeName();
-				int n = (int) keys.count(nodeName);
-				if (n)
-					range.push_back(nodeName + "[" + NumberFormatter::format(n) + "]");
+				size_t& count = keys[nodeName];
+				if (count)
+					range.push_back(nodeName + "[" + NumberFormatter::format(count) + "]");
 				else
 					range.push_back(nodeName);
-				keys.insert(nodeName);
+				++count;
 			}
 			pChild = pChild->nextSibling();
 		}


### PR DESCRIPTION
This more optimal way to assign sequential ids to elements with the same name