### PR TITLE
Increase HTTP chunk size

### DIFF
--- a/Net/include/Poco/Net/HTTPBufferAllocator.h
+++ b/Net/include/Poco/Net/HTTPBufferAllocator.h
@@ -36,7 +36,7 @@ public:
 
 	enum
 	{
-		BUFFER_SIZE = 4096
+		BUFFER_SIZE = 1024 * 128
 	};
 
 private:


### PR DESCRIPTION
The default chunk size of 4k (from 2006) leads to a lot of overhead for HTTP clients.  This change provides a major performance increase for some clients and makes more sense with current broadband speeds.