### PR TITLE
Uppercase usage:->Usage: for consistent formatting

### DIFF
--- a/Util/src/HelpFormatter.cpp
+++ b/Util/src/HelpFormatter.cpp
@@ -69,7 +69,7 @@ void HelpFormatter::setFooter(const std::string& footer)
 
 void HelpFormatter::format(std::ostream& ostr) const
 {
-	ostr << "usage: " << _command;
+	ostr << "Usage: " << _command;
 	if (!_usage.empty())
 	{
 		ostr << ' ';


### PR DESCRIPTION
We have 'Usage:' in manually formatted help. Just not to use HelpFormatter everywhere(or stop using it in several apps) I propose to change it.